### PR TITLE
fix(skills): render simple icon svgs inside of react-icon-cloud

### DIFF
--- a/src/components/skills/Skills.jsx
+++ b/src/components/skills/Skills.jsx
@@ -1,22 +1,51 @@
 import './skills.scss'
-// import allIcons from 'simple-icons';
-import { v4 } from "uuid";
-import { Cloud } from "react-icon-cloud";
-import JS from '../../images/assets/js-logo.png'
-import VSC from '../../images/assets/visual-studio-code-logo.png'
-import Java from '../../images/assets/java-logo.png'
-import HTML5 from '../../images/assets/html5-logo.png'
-import CSS3 from '../../images/assets/css3-logo.png'
-import React from '../../images/assets/react-logo.png'
-import Rails from '../../images/assets/rails-logo.png'
-import Heroku from '../../images/assets/heroku-logo.svg'
-import MSOffice from '../../images/assets/msofficeicon-logo.png'
-import NPM from '../../images/assets/npm-logo.png'
-import Bootstrap from '../../images/assets/bootstrap-logo.png'
-import git from '../../images/assets/git-logo.png'
-import PostgreSQL from '../../images/assets/postgresql-logo.png'
-import SQL from '../../images/assets/sql-logo.png'
-import Github from '../../images/assets/github-logo.png'
+import { Cloud, renderSimpleIcon } from "react-icon-cloud";
+import {
+  siGithub,
+  siPostgresql,
+  siGit,
+  siBootstrap,
+  siNpm,
+  siMicrosoftoffice,
+  siHeroku,
+  siRubyonrails,
+  siReact,
+  siCss3,
+  siHtml5,
+  siJava,
+  siVisualstudiocode,
+  siJavascript,
+} from 'simple-icons/icons'
+
+function makeIcons(){
+  return [
+    siGithub,
+    siPostgresql,
+    siGit,
+    siBootstrap,
+    siNpm,
+    siMicrosoftoffice,
+    siHeroku,
+    siRubyonrails,
+    siReact,
+    siCss3,
+    siHtml5,
+    siJava,
+    siVisualstudiocode,
+    siJavascript,
+  ].map(icon => {
+    return renderSimpleIcon({
+      bgHex: '#fff',
+      fallbackHex: '#000',
+      icon,
+      minContrastRatio: 2,
+      size: 100,
+      aProps: {
+        onClick: e => e.preventDefault()
+      }
+    });
+  })
+}
 
 export default function Skills() {
 
@@ -114,41 +143,7 @@ export default function Skills() {
     // zoomMin: number
     // zoomStep: number
   }
-  // const iconSlugs = [
-  //   "JS",
-  //   "dart",
-  //   "java",
-  //   "react",
-  //   "flutter",
-  //   "android",
-  //   "html5",
-  //   "css3",
-  //   "nodedotjs",
-  //   "express",
-  //   "nextdotjs",
-  //   "prisma",
-  //   "amazonaws",
-  //   "postgresql",
-  //   "firebase",
-  //   "nginx",
-  //   "vercel",
-  //   "testinglibrary",
-  //   "jest",
-  //   "cypress",
-  //   "docker",
-  //   "git",
-  //   "jira",
-  //   "github",
-  //   "gitlab",
-  //   "visualstudiocode",
-  //   "androidstudio",
-  //   "sonarqube",
-  //   "figma"
-  // ];
-  // const iconTags = iconSlugs.map((slug) => ({
-  //   id: slug,
-  //   simpleIcon: allIcons.Get(slug)
-  // }));
+
 
 
   return (
@@ -157,62 +152,7 @@ export default function Skills() {
           <h1>Skills</h1>
         </div>
         <div id='icon-cloud'>
-          <Cloud
-            key={v4()}
-            id={"icon"}
-            minContrastRatio={1}
-            iconSize={100}
-            backgroundHexColor={"#fff"}
-            fallbackHexColor={"#000"}
-            options={options}
-            wheelZoom={false}
-            >
-              <a href=" " title="JS" rel="noopener">
-                <img src={JS} height="100" width="100" alt="JS"/>
-              </a>
-              <a href=" " title="VSC" rel="noopener">
-                <img src={VSC} height="100" width="100" alt="Visual Studio Code"/>
-              </a>
-              <a href=" " rel="noopener">
-                <img src={Java} height="100" width="100" alt="Java"/>
-              </a>
-              <a href=" " title="JS" rel="noopener">
-                <img src={HTML5} height="100" width="100" alt="HTML5"/>
-              </a>
-              <a href=" " title="JS" rel="noopener">
-                <img src={CSS3} height="100" width="100" alt="CSS3"/>
-              </a>
-              <a href=" " title="JS" rel="noopener">
-                <img src={React} height="100" width="100" alt="Rails"/>
-              </a>
-              <a href=" " title="JS" rel="noopener">
-                <img src={Rails} height="100" width="100" alt="Rails"/>
-              </a>
-              <a href=" " title="JS" rel="noopener">
-                <img src={Heroku} height="100" width="100" alt="Visual Studio Code"/>
-              </a>
-              <a href=" " title="JS" rel="noopener">
-                <img src={MSOffice} height="100" width="100" alt="Visual Studio Code"/>
-              </a>
-              <a href=" " title="JS" rel="noopener">
-                <img src={NPM} height="100" width="100" alt="Visual Studio Code"/>
-              </a>
-              <a href=" " title="JS" rel="noopener">
-                <img src={Bootstrap} height="100" width="100" alt="Visual Studio Code"/>
-              </a>
-              <a href=" " title="git" rel="noopener">
-                <img src={git} height="100" width="100" alt="git"/>
-              </a>
-              <a href=" " title="PostgreSQL" rel="noopener">
-                <img src={PostgreSQL} height="100" width="100" alt="PostgreSQL"/>
-              </a>
-              <a href=" " title="SQL" rel="noopener">
-                <img src={SQL} height="100" width="100" alt="PostgreSQL" />
-              </a>
-              <a href=" " title="Github" rel="noopener">
-                <img src={Github} height="100" width="100" alt="PostgreSQL" />
-              </a>
-            </Cloud>
+          <Cloud options={options}>{makeIcons()}</Cloud>
         </div>
     </div>
   )


### PR DESCRIPTION
Hey Camilo. Love the portfolio here. I saw that you are using my package react-icon-cloud to showcase some of the tools that you have used and I wanted to make sure you got the best use case out of this by using all the built in icons from simple-icons.

As i'm sure you found out, importing the default from simple icons may create a huge bundle size. This should work well for you instead. Please let me know if you have any questions about how to use this package. The prop types are documented for the Cloud component as well as the renderIcon function in the read me [here](https://github.com/teaguestockwell/react-icon-cloud)

You may have to play with the minContrastRatio of render icon for all the icons to be in full color.
<img width="1439" alt="Screen Shot 2022-02-06 at 22 10 13" src="https://user-images.githubusercontent.com/71202372/152733956-4304dafd-d956-497a-a9f3-fb7da76fdffa.png">

